### PR TITLE
Fix: exclude tests dir from copying phase

### DIFF
--- a/src/tasks/copy-template-files.ts
+++ b/src/tasks/copy-template-files.ts
@@ -24,7 +24,7 @@ const isGitKeepRegex = /\.gitkeep/;
 const excludePatterns = [
   /\.github\//,               // GitHub specific files todo: add workflows/main.yml later
   /CHANGELOG\.md/,            // Changelog file
-  /__test__/,                 // Test directories at any nesting level
+  /__test.*__/,               // All test directories (__test__, __tests__, etc.)
 ];
 
 const copyBaseFiles = async (


### PR DESCRIPTION
# Fix: exclude tests dir from copying phase

## Types of change

- [ ] Feature
- [X] Bug
- [ ] Enhancement

## Changes:
- Exclude `__test*__` in addition of comit 442a9a9f79d8217b0720bfabcc0bfc2c33050c40