### PR TITLE
fix: do not use scarb to format

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -46,7 +46,7 @@ export async function createProject(options: Options) {
       },
     },
     {
-      title: "🪄 Formatting files with prettier",
+      title: "🪄 Formatting Next.js files with prettier",
       task: () => prettierFormat(targetDirectory),
       skip: () => {
         if (!options.install) {

--- a/src/tasks/prettier-format.ts
+++ b/src/tasks/prettier-format.ts
@@ -1,14 +1,16 @@
 import { execa } from "execa";
+import path from "path";
 
 export async function prettierFormat(targetDir: string) {
   try {
-    const result = await execa("yarn", ["format"], { cwd: targetDir });
+    const nextjsPath = path.join(targetDir, "packages/nextjs");
+    const result = await execa("yarn", ["format"], { cwd: nextjsPath });
 
     if (result.failed) {
       throw new Error("There was a problem running the format command");
     }
   } catch (error) {
-    throw new Error("Failed to create directory", { cause: error });
+    throw new Error("Failed to format Next.js project", { cause: error });
   }
 
   return true;


### PR DESCRIPTION
This PR skips scarb contract formatting process in #19  to prevent errors due to scarb not installed. Need to confirm @gianalarcon if this is intended. 

Feel free to let me know  or suggest anything if we need to do alternative formatting in the contracts side.
