### PR TITLE
fix: error when `./`

### DIFF
--- a/src/tasks/create-project-directory.ts
+++ b/src/tasks/create-project-directory.ts
@@ -4,7 +4,16 @@ import fs from "fs";
 export async function createProjectDirectory(projectName: string) {
   // Check if directory already exists
   if (fs.existsSync(projectName)) {
-    throw new Error(`Directory ${projectName} already exists. Cannot continue with an existing directory.`);
+    // If directory exists, check if it's empty
+    if (fs.readdirSync(projectName).length > 0) {
+      throw new Error(
+        `Directory ${projectName} already exists and is not empty. Cannot continue.`,
+      );
+    }
+    // If directory exists and is empty, we can proceed (or do nothing here, as it's already created and empty)
+    // For clarity, we can return true or simply let the function continue if no further action is needed.
+    // In this case, since the directory exists and is empty, the goal is achieved.
+    return true;
   }
 
   try {
@@ -14,7 +23,11 @@ export async function createProjectDirectory(projectName: string) {
       throw new Error("There was a problem running the mkdir command");
     }
   } catch (error) {
-    throw new Error(`Failed to create directory: ${error instanceof Error ? error.message : String(error)}`);
+    throw new Error(
+      `Failed to create directory: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
   }
 
   return true;


### PR DESCRIPTION
The issue is caused because we checked the presence of directory instead of whether or not it is empty, switched to the latter mechanism

Fixes #19 